### PR TITLE
Keychain fix

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -113,6 +113,17 @@ public class DeterministicKey extends ECKey {
                             KeyCrypter crypter,
                             LazyECPoint pub,
                             EncryptedData priv,
+                            @Nullable DeterministicKey parent, long creationTimeSeconds) {
+        this(childNumberPath, chainCode, crypter, pub, priv, parent);
+        this.creationTimeSeconds = creationTimeSeconds;
+    }
+
+    /** Constructs a key from its components. This is not normally something you should use. */
+    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+                            byte[] chainCode,
+                            KeyCrypter crypter,
+                            LazyECPoint pub,
+                            EncryptedData priv,
                             @Nullable DeterministicKey parent) {
         this(childNumberPath, chainCode, pub, null, parent);
         this.encryptedPrivateKey = checkNotNull(priv);

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -100,6 +100,16 @@ public class DeterministicKey extends ECKey {
     /** Constructs a key from its components. This is not normally something you should use. */
     public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
                             byte[] chainCode,
+                            LazyECPoint publicAsPoint,
+                            @Nullable BigInteger priv,
+                            @Nullable DeterministicKey parent, long creationTimeSeconds) {
+        this(childNumberPath, chainCode, publicAsPoint, priv, parent);
+        this.creationTimeSeconds = creationTimeSeconds;
+    }
+
+    /** Constructs a key from its components. This is not normally something you should use. */
+    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+                            byte[] chainCode,
                             KeyCrypter crypter,
                             LazyECPoint pub,
                             EncryptedData priv,
@@ -107,6 +117,15 @@ public class DeterministicKey extends ECKey {
         this(childNumberPath, chainCode, pub, null, parent);
         this.encryptedPrivateKey = checkNotNull(priv);
         this.keyCrypter = checkNotNull(crypter);
+    }
+
+    /** Constructs a key from its components. This is not normally something you should use. */
+    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+                            byte[] chainCode,
+                            BigInteger priv,
+                            @Nullable DeterministicKey parent, long creationTimeSeconds) {
+        this(childNumberPath, chainCode, priv, parent);
+        this.creationTimeSeconds = creationTimeSeconds;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -135,7 +135,7 @@ public final class HDKeyDerivation {
                     rawKey.chainCode,
                     new LazyECPoint(ECKey.CURVE.getCurve(), rawKey.keyBytes),
                     null,
-                    parent);
+                    parent, System.currentTimeMillis() / 1000);
         } else {
             RawKeyBytes rawKey = deriveChildKeyBytesFromPrivate(parent, childNumber);
             return new DeterministicKey(
@@ -160,7 +160,7 @@ public final class HDKeyDerivation {
                     rawKey.chainCode,
                     new LazyECPoint(ECKey.CURVE.getCurve(), rawKey.keyBytes),
                     null,
-                    parent, creationTimeSeconds);
+                    parent);
         } else {
             RawKeyBytes rawKey = deriveChildKeyBytesFromPrivate(parent, childNumber);
             return new DeterministicKey(

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -146,6 +146,32 @@ public final class HDKeyDerivation {
         }
     }
 
+    /**
+     * @throws HDDerivationException if private derivation is attempted for a public-only parent key, or
+     * if the resulting derived key is invalid (eg. private key == 0).
+     */
+    public static DeterministicKey deriveChildKey(DeterministicKey parent, ChildNumber childNumber,
+                                                  long creationTimeSeconds)
+            throws HDDerivationException {
+        if (!parent.hasPrivKey()) {
+            RawKeyBytes rawKey = deriveChildKeyBytesFromPublic(parent, childNumber, PublicDeriveMode.NORMAL);
+            return new DeterministicKey(
+                    HDUtils.append(parent.getPath(), childNumber),
+                    rawKey.chainCode,
+                    new LazyECPoint(ECKey.CURVE.getCurve(), rawKey.keyBytes),
+                    null,
+                    parent, creationTimeSeconds);
+        } else {
+            RawKeyBytes rawKey = deriveChildKeyBytesFromPrivate(parent, childNumber);
+            return new DeterministicKey(
+                    HDUtils.append(parent.getPath(), childNumber),
+                    rawKey.chainCode,
+                    new BigInteger(1, rawKey.keyBytes),
+                    parent, creationTimeSeconds);
+        }
+    }
+
+
     public static RawKeyBytes deriveChildKeyBytesFromPrivate(DeterministicKey parent,
                                                               ChildNumber childNumber) throws HDDerivationException {
         checkArgument(parent.hasPrivKey(), "Parent key must have private key bytes for this method.");

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -45,6 +45,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     int uahfHeight = 478559;
     /** Activation time at which the cash HF kicks in. */
     protected long cashHardForkActivationTime;
+    protected int daaHeight;
 
     public AbstractBitcoinNetParams() {
         super();
@@ -64,7 +65,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     	final BlockStore blockStore, AbstractBlockChain blockChain) throws VerificationException, BlockStoreException {
         Block prev = storedPrev.getHeader();
 
-        if (blockChain.getMedianTimestampOfRecentBlocks(storedPrev, blockStore) >= cashHardForkActivationTime) {
+        if (storedPrev.getHeight() +1 >= daaHeight) {
             checkNextCashWorkRequired(storedPrev, nextBlock, blockStore);
             return;
         }
@@ -300,7 +301,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
      * block. Because timestamps are the least trustworthy information we have as
      * input, this ensures the algorithm is more resistant to malicious inputs.
      */
-    void checkNextCashWorkRequired(StoredBlock pindexPrev,
+    protected void checkNextCashWorkRequired(StoredBlock pindexPrev,
                                    Block pblock, BlockStore blockStore) {
         // This cannot handle the genesis block and early blocks in general.
         //assert(pindexPrev);

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -134,6 +134,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         uahfHeight = 478559;
         /** Activation time at which the cash HF kicks in. */
         cashHardForkActivationTime = 1510600000;
+        daaHeight = 504032;
     }
 
     private static MainNetParams instance;

--- a/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
@@ -56,6 +56,10 @@ public class TestNet2Params extends AbstractBitcoinNetParams {
         majorityEnforceBlockUpgrade = TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED;
         majorityWindow = TESTNET_MAJORITY_WINDOW;
+
+        /** Activation time at which the cash HF kicks in. */
+        cashHardForkActivationTime = 1510600000;
+        daaHeight = 1188697;
     }
 
     private static TestNet2Params instance;

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -20,6 +20,7 @@ package org.bitcoinj.params;
 import java.math.BigInteger;
 import java.util.Date;
 
+import com.google.common.base.Preconditions;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.NetworkParameters;
@@ -79,6 +80,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
         /** Activation time at which the cash HF kicks in. */
         cashHardForkActivationTime = 1510600000;
+        daaHeight = 1188697;
     }
 
     private static TestNet3Params instance;
@@ -100,7 +102,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
     @Override
     public void checkDifficultyTransitions(final StoredBlock storedPrev, final Block nextBlock,
                                            final BlockStore blockStore, AbstractBlockChain blockChain) throws VerificationException, BlockStoreException {
-        if (!isDifficultyTransitionPoint(storedPrev) && nextBlock.getTime().after(testnetDiffDate)) {
+        if (storedPrev.getHeight() < daaHeight && !isDifficultyTransitionPoint(storedPrev) && nextBlock.getTime().after(testnetDiffDate)) {
             Block prev = storedPrev.getHeader();
 
             // After 15th February 2012 the rules on the testnet change to avoid people running up the difficulty
@@ -126,6 +128,67 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
             }
         } else {
             super.checkDifficultyTransitions(storedPrev, nextBlock, blockStore, blockChain);
+        }
+    }
+    @Override
+    protected void checkNextCashWorkRequired(StoredBlock storedPrev,
+                                   Block nextBlock, BlockStore blockStore) {
+        // This cannot handle the genesis block and early blocks in general.
+        //assert(pindexPrev);
+
+
+
+        // Compute the difficulty based on the full adjustement interval.
+        int nHeight = storedPrev.getHeight();
+        Preconditions.checkState(nHeight >= this.interval);
+
+        // Get the last suitable block of the difficulty interval.
+        try {
+
+            // Special difficulty rule for testnet:
+            // If the new block's timestamp is more than 2* 10 minutes then allow
+            // mining of a min-difficulty block.
+
+                Block prev = storedPrev.getHeader();
+
+
+                final long timeDelta = nextBlock.getTimeSeconds() - prev.getTimeSeconds();
+                if (timeDelta >= 0 && timeDelta > NetworkParameters.TARGET_SPACING * 2) {
+                    if (!maxTarget.equals(nextBlock.getDifficultyTargetAsInteger()))
+                        throw new VerificationException("Testnet block transition that is not allowed: " +
+                                Long.toHexString(Utils.encodeCompactBits(maxTarget)) + " (required min difficulty) vs " +
+                                Long.toHexString(nextBlock.getDifficultyTarget()));
+                    return;
+                }
+
+            StoredBlock pindexLast = GetSuitableBlock(storedPrev, blockStore);
+            //assert (pindexLast);
+
+            // Get the first suitable block of the difficulty interval.
+            int nHeightFirst = nHeight - 144;
+
+            StoredBlock pindexFirst = storedPrev;
+
+            for (int i = 144; i > 0; --i)
+            {
+                pindexFirst = pindexFirst.getPrev(blockStore);
+                if(pindexFirst == null)
+                    return;
+            }
+
+            pindexFirst = GetSuitableBlock(pindexFirst, blockStore);
+            //assert (pindexFirst);
+
+            // Compute the target based on time and work done during the interval.
+            BigInteger nextTarget =
+                    ComputeTarget(pindexFirst, pindexLast);
+
+            verifyDifficulty(nextTarget, nextBlock);
+        }
+        catch (BlockStoreException x)
+        {
+            //this means we don't have enough blocks, yet.  let it go until we do.
+            return;
         }
     }
 }

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -55,8 +55,9 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         majorityRejectBlockOutdated = 4;
         majorityWindow = 7;
 
-        // support for legacy tests - dont test BCH 2017-11-1 hardfork by default
+        // support for legacy tests - dont test BCH 2017-11-13 hardfork by default
         cashHardForkActivationTime = (System.currentTimeMillis()/1000)+24*60*60;
+        daaHeight = 1000000;
     }
 
     private static UnitTestParams instance;

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
@@ -60,4 +60,27 @@ public class DefaultKeyChainFactory implements KeyChainFactory {
             chain = new DeterministicKeyChain(accountKey, isFollowingKey);
         return chain;
     }
+
+    @Override
+    public DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey,
+                                                      boolean isMarried) throws UnreadableWalletException {
+        DeterministicKeyChain chain;
+        if (isMarried)
+            chain = new MarriedKeyChain(accountKey);
+        else
+            chain = DeterministicKeyChain.spend(accountKey);
+        return chain;
+    }
+
+    @Override
+    public DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey,
+                                                      boolean isMarried, ImmutableList<ChildNumber> accountPath)
+            throws UnreadableWalletException {
+        DeterministicKeyChain chain;
+        if (isMarried)
+            chain = new MarriedKeyChain(accountKey);
+        else
+            chain = DeterministicKeyChain.spend(accountKey, accountPath); // this needs to be simplified
+        return chain;
+    }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
@@ -16,7 +16,10 @@
 
 package org.bitcoinj.wallet;
 
+import com.google.common.collect.ImmutableList;
 import org.bitcoinj.crypto.*;
+
+import java.util.List;
 
 /**
  * Default factory for creating keychains while de-serializing.
@@ -29,6 +32,18 @@ public class DefaultKeyChainFactory implements KeyChainFactory {
             chain = new MarriedKeyChain(seed, crypter);
         else
             chain = new DeterministicKeyChain(seed, crypter);
+        return chain;
+    }
+
+    @Override
+    public DeterministicKeyChain makeKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicSeed seed, KeyCrypter crypter, boolean isMarried, String originalAccountPath) {
+        DeterministicKeyChain chain;
+        if (isMarried)
+            chain = new MarriedKeyChain(seed, crypter);
+        else {
+            List<ChildNumber> childNumber = HDUtils.parsePath(originalAccountPath);
+            chain = new DeterministicKeyChain(seed, crypter, ImmutableList.<ChildNumber>builder().addAll(childNumber).build());
+        }
         return chain;
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -843,11 +843,11 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             detKey.setChainCode(ByteString.copyFrom(key.getChainCode()));
             for (ChildNumber num : key.getPath())
                 detKey.addPath(num.i());
-            if (key.equals(externalParentKey)) {
+            if (Arrays.equals(key.getPubKey(), externalParentKey.getPubKey())) {
                 detKey.setIssuedSubkeys(issuedExternalKeys);
                 detKey.setLookaheadSize(lookaheadSize);
                 detKey.setSigsRequiredToSpend(getSigsRequiredToSpend());
-            } else if (key.equals(internalParentKey)) {
+            } else if (Arrays.equals(key.getPubKey(), internalParentKey.getPubKey())) {
                 detKey.setIssuedSubkeys(issuedInternalKeys);
                 detKey.setLookaheadSize(lookaheadSize);
                 detKey.setSigsRequiredToSpend(getSigsRequiredToSpend());

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
@@ -34,6 +34,19 @@ public interface KeyChainFactory {
      */
     DeterministicKeyChain makeKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicSeed seed, KeyCrypter crypter, boolean isMarried);
 
+
+    /**
+     * Make a keychain (but not a watching one) with the specified account path
+     *
+     * @param key the protobuf for the root key
+     * @param firstSubKey the protobuf for the first child key (normally the parent of the external subchain)
+     * @param seed the seed
+     * @param crypter the encrypted/decrypter
+     * @param isMarried whether the keychain is leading in a marriage
+     * @param originalAccountPath the specified account path
+     */
+    DeterministicKeyChain makeKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicSeed seed, KeyCrypter crypter, boolean isMarried, String originalAccountPath);
+
     /**
      * Make a watching keychain.
      *

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.wallet;
 
+import com.google.common.collect.ImmutableList;
+import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 
@@ -59,4 +61,31 @@ public interface KeyChainFactory {
      * @param isMarried whether the keychain is leading in a marriage
      */
     DeterministicKeyChain makeWatchingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey, boolean isFollowingKey, boolean isMarried) throws UnreadableWalletException;
+
+    /**
+     * Make a spending keychain.
+     *
+     * <p>isMarried and isFollowingKey must not be true at the same time.
+     *
+     * @param key the protobuf for the account key
+     * @param firstSubKey the protobuf for the first child key (normally the parent of the external subchain)
+     * @param accountKey the account extended public key
+     * @param isMarried whether the keychain is leading in a marriage
+     */
+    DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey,
+                                               boolean isMarried) throws UnreadableWalletException;
+
+    /**
+     * Make a spending keychain.
+     *
+     * <p>isMarried and isFollowingKey must not be true at the same time.
+     *
+     * @param key the protobuf for the account key
+     * @param firstSubKey the protobuf for the first child key (normally the parent of the external subchain)
+     * @param accountKey the account extended public key
+     * @param isMarried whether the keychain is leading in a marriage
+     */
+    DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey,
+                                               boolean isMarried, ImmutableList<ChildNumber> accountPath)
+            throws UnreadableWalletException;
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -84,12 +84,32 @@ public class KeyChainGroup implements KeyBag {
         this(params, null, ImmutableList.of(new DeterministicKeyChain(seed)), null, null);
     }
 
+    public KeyChainGroup(NetworkParameters params, DeterministicSeed seed, ImmutableList<ChildNumber> accountPath) {
+        this(params, null, ImmutableList.of(new DeterministicKeyChain(seed, accountPath)), null, null);
+    }
+
     /**
      * Creates a keychain group with no basic chain, and an HD chain that is watching the given watching key.
      * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
      */
     public KeyChainGroup(NetworkParameters params, DeterministicKey watchKey) {
         this(params, null, ImmutableList.of(DeterministicKeyChain.watch(watchKey)), null, null);
+    }
+
+    /**
+     * Creates a keychain group with no basic chain, and an HD chain that is watching the given watching key.
+     * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
+     */
+    public KeyChainGroup(NetworkParameters params, DeterministicKey watchKey, ImmutableList<ChildNumber> accountPath) {
+        this(params, null, ImmutableList.of(DeterministicKeyChain.watch(watchKey, accountPath)), null, null);
+    }
+
+    /**
+     * Creates a keychain group with no basic chain, and an HD chain that is watching or spending the given key.
+     * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
+     */
+    public KeyChainGroup(NetworkParameters params, DeterministicKey watchKey, boolean watch) {
+        this(params, null, ImmutableList.of(watch ? DeterministicKeyChain.watch(watchKey) : DeterministicKeyChain.spend(watchKey)), null, null);
     }
 
     // Used for deserialization.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -112,6 +112,18 @@ public class KeyChainGroup implements KeyBag {
         this(params, null, ImmutableList.of(watch ? DeterministicKeyChain.watch(watchKey) : DeterministicKeyChain.spend(watchKey)), null, null);
     }
 
+    /**
+     * Creates a keychain group with no basic chain, and an HD chain that is watching or spending the given key.
+     * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
+     */
+    public KeyChainGroup(NetworkParameters params, DeterministicKey watchKey, boolean watch,
+                         ImmutableList<ChildNumber> accountPath) {
+        this(params, null,
+                ImmutableList.of(watch ? DeterministicKeyChain.watch(watchKey, accountPath)
+                        : DeterministicKeyChain.spend(watchKey, accountPath)),
+                null, null);
+    }
+
     // Used for deserialization.
     private KeyChainGroup(NetworkParameters params, @Nullable BasicKeyChain basicKeyChain, List<DeterministicKeyChain> chains,
                           @Nullable EnumMap<KeyChain.KeyPurpose, DeterministicKey> currentKeys, @Nullable KeyCrypter crypter) {
@@ -663,6 +675,8 @@ public class KeyChainGroup implements KeyBag {
         return fromProtobufUnencrypted(params, keys, new DefaultKeyChainFactory());
     }
 
+
+
     public static KeyChainGroup fromProtobufUnencrypted(NetworkParameters params, List<Protos.Key> keys, KeyChainFactory factory) throws UnreadableWalletException {
         BasicKeyChain basicKeyChain = BasicKeyChain.fromProtobufUnencrypted(keys);
         List<DeterministicKeyChain> chains = DeterministicKeyChain.fromProtobuf(keys, null, factory);
@@ -686,6 +700,20 @@ public class KeyChainGroup implements KeyBag {
             currentKeys = createCurrentKeysMap(chains);
         extractFollowingKeychains(chains);
         return new KeyChainGroup(params, basicKeyChain, chains, currentKeys, crypter);
+    }
+
+    /**
+     * Creates a keychain group with no basic chain, and an HD chain that is watching the given watching key.
+     * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
+     */
+    static KeyChainGroup createSpendingOrWatchingKeyChainGroup(NetworkParameters params, DeterministicKey key,
+                                                               boolean spend) {
+        if (spend) {
+            return new KeyChainGroup(params, null, ImmutableList.of(DeterministicKeyChain.spend(key)),
+                    null, null);
+        } else {
+            return new KeyChainGroup(params, key);
+        }
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -445,15 +445,15 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasIpAddress()) {
-          
+
           return false;
         }
         if (!hasPort()) {
-          
+
           return false;
         }
         if (!hasServices()) {
-          
+
           return false;
         }
         return true;
@@ -1007,11 +1007,11 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasInitialisationVector()) {
-          
+
           return false;
         }
         if (!hasEncryptedPrivateKey()) {
-          
+
           return false;
         }
         return true;
@@ -1899,7 +1899,7 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasChainCode()) {
-          
+
           return false;
         }
         return true;
@@ -2476,6 +2476,32 @@ public final class Protos {
      * </pre>
      */
     org.bitcoinj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDeterministicSeedOrBuilder();
+
+
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    boolean hasAccountPath();
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    java.lang.String getAccountPath();
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    com.google.protobuf.ByteString getAccountPathBytes();
   }
   /**
    * Protobuf type {@code wallet.Key}
@@ -2614,6 +2640,12 @@ public final class Protos {
               bitField0_ |= 0x00000100;
               break;
             }
+            case 82: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000200;
+              accountPath_ = bs;
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2662,7 +2694,7 @@ public final class Protos {
        * <code>ORIGINAL = 1;</code>
        *
        * <pre>
-       ** Unencrypted - Original bitcoin secp256k1 curve 
+       ** Unencrypted - Original bitcoin secp256k1 curve
        * </pre>
        */
       ORIGINAL(0, 1),
@@ -2670,7 +2702,7 @@ public final class Protos {
        * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        *
        * <pre>
-       ** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve 
+       ** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve
        * </pre>
        */
       ENCRYPTED_SCRYPT_AES(1, 2),
@@ -2703,7 +2735,7 @@ public final class Protos {
        * <code>ORIGINAL = 1;</code>
        *
        * <pre>
-       ** Unencrypted - Original bitcoin secp256k1 curve 
+       ** Unencrypted - Original bitcoin secp256k1 curve
        * </pre>
        */
       public static final int ORIGINAL_VALUE = 1;
@@ -2711,7 +2743,7 @@ public final class Protos {
        * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        *
        * <pre>
-       ** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve 
+       ** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve
        * </pre>
        */
       public static final int ENCRYPTED_SCRYPT_AES_VALUE = 2;
@@ -2922,7 +2954,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2942,7 +2974,7 @@ public final class Protos {
         getLabelBytes() {
       java.lang.Object ref = label_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         label_ = b;
@@ -3056,6 +3088,59 @@ public final class Protos {
       return encryptedDeterministicSeed_;
     }
 
+    public static final int ACCOUNT_PATH_FIELD_NUMBER = 10;
+    private java.lang.Object accountPath_;
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    public boolean hasAccountPath() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    public java.lang.String getAccountPath() {
+      java.lang.Object ref = accountPath_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          accountPath_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string account_path = 10;</code>
+     *
+     * <pre>
+     * The original account path
+     * </pre>
+     */
+    public com.google.protobuf.ByteString getAccountPathBytes() {
+      java.lang.Object ref = accountPath_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8(
+                        (java.lang.String) ref);
+        accountPath_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private void initFields() {
       type_ = org.bitcoinj.wallet.Protos.Key.Type.ORIGINAL;
       secretBytes_ = com.google.protobuf.ByteString.EMPTY;
@@ -3066,6 +3151,7 @@ public final class Protos {
       deterministicKey_ = org.bitcoinj.wallet.Protos.DeterministicKey.getDefaultInstance();
       deterministicSeed_ = com.google.protobuf.ByteString.EMPTY;
       encryptedDeterministicSeed_ = org.bitcoinj.wallet.Protos.EncryptedData.getDefaultInstance();
+      accountPath_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3129,6 +3215,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         output.writeMessage(9, encryptedDeterministicSeed_);
       }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeBytes(10, getAccountPathBytes());
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3173,6 +3262,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(9, encryptedDeterministicSeed_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+                .computeBytesSize(10, getAccountPathBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3333,6 +3426,8 @@ public final class Protos {
           encryptedDeterministicSeedBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000100);
+        accountPath_ = "";
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -3409,6 +3504,10 @@ public final class Protos {
         } else {
           result.encryptedDeterministicSeed_ = encryptedDeterministicSeedBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.accountPath_ = accountPath_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3454,30 +3553,35 @@ public final class Protos {
         if (other.hasEncryptedDeterministicSeed()) {
           mergeEncryptedDeterministicSeed(other.getEncryptedDeterministicSeed());
         }
+        if (other.hasAccountPath()) {
+          bitField0_ |= 0x00000200;
+          accountPath_ = other.accountPath_;
+          onChanged();
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
 
       public final boolean isInitialized() {
         if (!hasType()) {
-          
+
           return false;
         }
         if (hasEncryptedData()) {
           if (!getEncryptedData().isInitialized()) {
-            
+
             return false;
           }
         }
         if (hasDeterministicKey()) {
           if (!getDeterministicKey().isInitialized()) {
-            
+
             return false;
           }
         }
         if (hasEncryptedDeterministicSeed()) {
           if (!getEncryptedDeterministicSeed().isInitialized()) {
-            
+
             return false;
           }
         }
@@ -3732,7 +3836,7 @@ public final class Protos {
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.EncryptedData, org.bitcoinj.wallet.Protos.EncryptedData.Builder, org.bitcoinj.wallet.Protos.EncryptedDataOrBuilder> 
+          org.bitcoinj.wallet.Protos.EncryptedData, org.bitcoinj.wallet.Protos.EncryptedData.Builder, org.bitcoinj.wallet.Protos.EncryptedDataOrBuilder>
           getEncryptedDataFieldBuilder() {
         if (encryptedDataBuilder_ == null) {
           encryptedDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -3843,7 +3947,7 @@ public final class Protos {
           getLabelBytes() {
         java.lang.Object ref = label_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           label_ = b;
@@ -4055,7 +4159,7 @@ public final class Protos {
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.DeterministicKey, org.bitcoinj.wallet.Protos.DeterministicKey.Builder, org.bitcoinj.wallet.Protos.DeterministicKeyOrBuilder> 
+          org.bitcoinj.wallet.Protos.DeterministicKey, org.bitcoinj.wallet.Protos.DeterministicKey.Builder, org.bitcoinj.wallet.Protos.DeterministicKeyOrBuilder>
           getDeterministicKeyFieldBuilder() {
         if (deterministicKeyBuilder_ == null) {
           deterministicKeyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -4262,7 +4366,7 @@ public final class Protos {
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.EncryptedData, org.bitcoinj.wallet.Protos.EncryptedData.Builder, org.bitcoinj.wallet.Protos.EncryptedDataOrBuilder> 
+          org.bitcoinj.wallet.Protos.EncryptedData, org.bitcoinj.wallet.Protos.EncryptedData.Builder, org.bitcoinj.wallet.Protos.EncryptedDataOrBuilder>
           getEncryptedDeterministicSeedFieldBuilder() {
         if (encryptedDeterministicSeedBuilder_ == null) {
           encryptedDeterministicSeedBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -4274,6 +4378,107 @@ public final class Protos {
         }
         return encryptedDeterministicSeedBuilder_;
       }
+
+      private java.lang.Object accountPath_ = "";
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public boolean hasAccountPath() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public java.lang.String getAccountPath() {
+        java.lang.Object ref = accountPath_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+                  (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            accountPath_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+      getAccountPathBytes() {
+        java.lang.Object ref = accountPath_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+                  com.google.protobuf.ByteString.copyFromUtf8(
+                          (java.lang.String) ref);
+          accountPath_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public Builder setAccountPath(
+              java.lang.String value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000200;
+        accountPath_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public Builder clearAccountPath() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        accountPath_ = getDefaultInstance().getAccountPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string account_path = 10;</code>
+       *
+       * <pre>
+       * The original account path
+       * </pre>
+       */
+      public Builder setAccountPathBytes(
+              com.google.protobuf.ByteString value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000200;
+        accountPath_ = value;
+        onChanged();
+        return this;
+      }
+
 
       // @@protoc_insertion_point(builder_scope:wallet.Key)
     }
@@ -4693,11 +4898,11 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasProgram()) {
-          
+
           return false;
         }
         if (!hasCreationTimestamp()) {
-          
+
           return false;
         }
         return true;
@@ -5429,15 +5634,15 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasTransactionOutPointHash()) {
-          
+
           return false;
         }
         if (!hasTransactionOutPointIndex()) {
-          
+
           return false;
         }
         if (!hasScriptBytes()) {
-          
+
           return false;
         }
         return true;
@@ -6246,11 +6451,11 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasValue()) {
-          
+
           return false;
         }
         if (!hasScriptBytes()) {
-          
+
           return false;
         }
         return true;
@@ -6549,7 +6754,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.PeerAddress> 
+    java.util.List<org.bitcoinj.wallet.Protos.PeerAddress>
         getBroadcastByList();
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
@@ -6562,7 +6767,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder>
         getBroadcastByOrBuilderList();
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
@@ -7142,7 +7347,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder>
         getBroadcastByOrBuilderList() {
       return broadcastBy_;
     }
@@ -7540,7 +7745,7 @@ public final class Protos {
               broadcastByBuilder_ = null;
               broadcastBy_ = other.broadcastBy_;
               bitField0_ = (bitField0_ & ~0x00000010);
-              broadcastByBuilder_ = 
+              broadcastByBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getBroadcastByFieldBuilder() : null;
             } else {
@@ -7561,7 +7766,7 @@ public final class Protos {
       public final boolean isInitialized() {
         for (int i = 0; i < getBroadcastByCount(); i++) {
           if (!getBroadcastBy(i).isInitialized()) {
-            
+
             return false;
           }
         }
@@ -7992,7 +8197,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.PeerAddressOrBuilder>
            getBroadcastByOrBuilderList() {
         if (broadcastByBuilder_ != null) {
           return broadcastByBuilder_.getMessageOrBuilderList();
@@ -8018,12 +8223,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.PeerAddress.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.PeerAddress.Builder>
            getBroadcastByBuilderList() {
         return getBroadcastByFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.PeerAddress, org.bitcoinj.wallet.Protos.PeerAddress.Builder, org.bitcoinj.wallet.Protos.PeerAddressOrBuilder> 
+          org.bitcoinj.wallet.Protos.PeerAddress, org.bitcoinj.wallet.Protos.PeerAddress.Builder, org.bitcoinj.wallet.Protos.PeerAddressOrBuilder>
           getBroadcastByFieldBuilder() {
         if (broadcastByBuilder_ == null) {
           broadcastByBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -8221,7 +8426,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.TransactionInput> 
+    java.util.List<org.bitcoinj.wallet.Protos.TransactionInput>
         getTransactionInputList();
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
@@ -8234,7 +8439,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder>
         getTransactionInputOrBuilderList();
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
@@ -8245,7 +8450,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.TransactionOutput> 
+    java.util.List<org.bitcoinj.wallet.Protos.TransactionOutput>
         getTransactionOutputList();
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
@@ -8258,7 +8463,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder>
         getTransactionOutputOrBuilderList();
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
@@ -8623,13 +8828,13 @@ public final class Protos {
      * <pre>
      **
      * This is a bitfield oriented enum, with the following bits:
-     * 
+     *
      * bit 0 - spent
      * bit 1 - appears in alt chain
      * bit 2 - appears in best chain
      * bit 3 - double-spent
      * bit 4 - pending (we would like the tx to go into the best chain)
-     * 
+     *
      * Not all combinations are interesting, just the ones actually used in the enum.
      * </pre>
      */
@@ -9092,7 +9297,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder>
         getTransactionInputOrBuilderList() {
       return transactionInput_;
     }
@@ -9127,7 +9332,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder>
         getTransactionOutputOrBuilderList() {
       return transactionOutput_;
     }
@@ -9317,7 +9522,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -9338,7 +9543,7 @@ public final class Protos {
         getMemoBytes() {
       java.lang.Object ref = memo_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         memo_ = b;
@@ -9830,7 +10035,7 @@ public final class Protos {
               transactionInputBuilder_ = null;
               transactionInput_ = other.transactionInput_;
               bitField0_ = (bitField0_ & ~0x00000020);
-              transactionInputBuilder_ = 
+              transactionInputBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getTransactionInputFieldBuilder() : null;
             } else {
@@ -9856,7 +10061,7 @@ public final class Protos {
               transactionOutputBuilder_ = null;
               transactionOutput_ = other.transactionOutput_;
               bitField0_ = (bitField0_ & ~0x00000040);
-              transactionOutputBuilder_ = 
+              transactionOutputBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getTransactionOutputFieldBuilder() : null;
             } else {
@@ -9904,34 +10109,34 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasVersion()) {
-          
+
           return false;
         }
         if (!hasHash()) {
-          
+
           return false;
         }
         for (int i = 0; i < getTransactionInputCount(); i++) {
           if (!getTransactionInput(i).isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getTransactionOutputCount(); i++) {
           if (!getTransactionOutput(i).isInitialized()) {
-            
+
             return false;
           }
         }
         if (hasConfidence()) {
           if (!getConfidence().isInitialized()) {
-            
+
             return false;
           }
         }
         if (hasExchangeRate()) {
           if (!getExchangeRate().isInitialized()) {
-            
+
             return false;
           }
         }
@@ -10394,7 +10599,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionInputOrBuilder>
            getTransactionInputOrBuilderList() {
         if (transactionInputBuilder_ != null) {
           return transactionInputBuilder_.getMessageOrBuilderList();
@@ -10420,12 +10625,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.TransactionInput.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.TransactionInput.Builder>
            getTransactionInputBuilderList() {
         return getTransactionInputFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.TransactionInput, org.bitcoinj.wallet.Protos.TransactionInput.Builder, org.bitcoinj.wallet.Protos.TransactionInputOrBuilder> 
+          org.bitcoinj.wallet.Protos.TransactionInput, org.bitcoinj.wallet.Protos.TransactionInput.Builder, org.bitcoinj.wallet.Protos.TransactionInputOrBuilder>
           getTransactionInputFieldBuilder() {
         if (transactionInputBuilder_ == null) {
           transactionInputBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -10634,7 +10839,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder>
            getTransactionOutputOrBuilderList() {
         if (transactionOutputBuilder_ != null) {
           return transactionOutputBuilder_.getMessageOrBuilderList();
@@ -10660,12 +10865,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.TransactionOutput.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.TransactionOutput.Builder>
            getTransactionOutputBuilderList() {
         return getTransactionOutputFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.TransactionOutput, org.bitcoinj.wallet.Protos.TransactionOutput.Builder, org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder> 
+          org.bitcoinj.wallet.Protos.TransactionOutput, org.bitcoinj.wallet.Protos.TransactionOutput.Builder, org.bitcoinj.wallet.Protos.TransactionOutputOrBuilder>
           getTransactionOutputFieldBuilder() {
         if (transactionOutputBuilder_ == null) {
           transactionOutputBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -10991,7 +11196,7 @@ public final class Protos {
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.TransactionConfidence, org.bitcoinj.wallet.Protos.TransactionConfidence.Builder, org.bitcoinj.wallet.Protos.TransactionConfidenceOrBuilder> 
+          org.bitcoinj.wallet.Protos.TransactionConfidence, org.bitcoinj.wallet.Protos.TransactionConfidence.Builder, org.bitcoinj.wallet.Protos.TransactionConfidenceOrBuilder>
           getConfidenceFieldBuilder() {
         if (confidenceBuilder_ == null) {
           confidenceBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -11178,7 +11383,7 @@ public final class Protos {
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.ExchangeRate, org.bitcoinj.wallet.Protos.ExchangeRate.Builder, org.bitcoinj.wallet.Protos.ExchangeRateOrBuilder> 
+          org.bitcoinj.wallet.Protos.ExchangeRate, org.bitcoinj.wallet.Protos.ExchangeRate.Builder, org.bitcoinj.wallet.Protos.ExchangeRateOrBuilder>
           getExchangeRateFieldBuilder() {
         if (exchangeRateBuilder_ == null) {
           exchangeRateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -11237,7 +11442,7 @@ public final class Protos {
           getMemoBytes() {
         java.lang.Object ref = memo_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           memo_ = b;
@@ -11863,7 +12068,7 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasSalt()) {
-          
+
           return false;
         }
         return true;
@@ -12158,7 +12363,7 @@ public final class Protos {
    * Protobuf type {@code wallet.Extension}
    *
    * <pre>
-   ** An extension to the wallet 
+   ** An extension to the wallet
    * </pre>
    */
   public static final class Extension extends
@@ -12290,7 +12495,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -12310,7 +12515,7 @@ public final class Protos {
         getIdBytes() {
       java.lang.Object ref = id_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         id_ = b;
@@ -12504,7 +12709,7 @@ public final class Protos {
      * Protobuf type {@code wallet.Extension}
      *
      * <pre>
-     ** An extension to the wallet 
+     ** An extension to the wallet
      * </pre>
      */
     public static final class Builder extends
@@ -12622,15 +12827,15 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasId()) {
-          
+
           return false;
         }
         if (!hasData()) {
-          
+
           return false;
         }
         if (!hasMandatory()) {
-          
+
           return false;
         }
         return true;
@@ -12698,7 +12903,7 @@ public final class Protos {
           getIdBytes() {
         java.lang.Object ref = id_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           id_ = b;
@@ -13010,7 +13215,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -13026,7 +13231,7 @@ public final class Protos {
         getTagBytes() {
       java.lang.Object ref = tag_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         tag_ = b;
@@ -13293,11 +13498,11 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasTag()) {
-          
+
           return false;
         }
         if (!hasData()) {
-          
+
           return false;
         }
         return true;
@@ -13353,7 +13558,7 @@ public final class Protos {
           getTagBytes() {
         java.lang.Object ref = tag_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           tag_ = b;
@@ -13623,7 +13828,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -13643,7 +13848,7 @@ public final class Protos {
         getClassNameBytes() {
       java.lang.Object ref = className_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         className_ = b;
@@ -13912,7 +14117,7 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasClassName()) {
-          
+
           return false;
         }
         return true;
@@ -13980,7 +14185,7 @@ public final class Protos {
           getClassNameBytes() {
         java.lang.Object ref = className_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           className_ = b;
@@ -14175,7 +14380,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Key key = 3;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.Key> 
+    java.util.List<org.bitcoinj.wallet.Protos.Key>
         getKeyList();
     /**
      * <code>repeated .wallet.Key key = 3;</code>
@@ -14188,7 +14393,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Key key = 3;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder>
         getKeyOrBuilderList();
     /**
      * <code>repeated .wallet.Key key = 3;</code>
@@ -14199,7 +14404,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.Transaction> 
+    java.util.List<org.bitcoinj.wallet.Protos.Transaction>
         getTransactionList();
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
@@ -14212,7 +14417,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder>
         getTransactionOrBuilderList();
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
@@ -14223,7 +14428,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.Script> 
+    java.util.List<org.bitcoinj.wallet.Protos.Script>
         getWatchedScriptList();
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
@@ -14236,7 +14441,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder>
         getWatchedScriptOrBuilderList();
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
@@ -14290,7 +14495,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.Extension> 
+    java.util.List<org.bitcoinj.wallet.Protos.Extension>
         getExtensionList();
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
@@ -14303,7 +14508,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder>
         getExtensionOrBuilderList();
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
@@ -14361,7 +14566,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.Tag> 
+    java.util.List<org.bitcoinj.wallet.Protos.Tag>
         getTagsList();
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
@@ -14374,7 +14579,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder>
         getTagsOrBuilderList();
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
@@ -14389,7 +14594,7 @@ public final class Protos {
      * transaction signers added to the wallet
      * </pre>
      */
-    java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> 
+    java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner>
         getTransactionSignersList();
     /**
      * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
@@ -14414,7 +14619,7 @@ public final class Protos {
      * transaction signers added to the wallet
      * </pre>
      */
-    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder>
         getTransactionSignersOrBuilderList();
     /**
      * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
@@ -14430,7 +14635,7 @@ public final class Protos {
    * Protobuf type {@code wallet.Wallet}
    *
    * <pre>
-   ** A bitcoin wallet 
+   ** A bitcoin wallet
    * </pre>
    */
   public static final class Wallet extends
@@ -14779,7 +14984,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -14799,7 +15004,7 @@ public final class Protos {
         getNetworkIdentifierBytes() {
       java.lang.Object ref = networkIdentifier_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         networkIdentifier_ = b;
@@ -14881,7 +15086,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Key key = 3;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder>
         getKeyOrBuilderList() {
       return key_;
     }
@@ -14916,7 +15121,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder>
         getTransactionOrBuilderList() {
       return transaction_;
     }
@@ -14951,7 +15156,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder>
         getWatchedScriptOrBuilderList() {
       return watchedScript_;
     }
@@ -15049,7 +15254,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder>
         getExtensionOrBuilderList() {
       return extension_;
     }
@@ -15097,7 +15302,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -15117,7 +15322,7 @@ public final class Protos {
         getDescriptionBytes() {
       java.lang.Object ref = description_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         description_ = b;
@@ -15165,7 +15370,7 @@ public final class Protos {
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder>
         getTagsOrBuilderList() {
       return tags_;
     }
@@ -15208,7 +15413,7 @@ public final class Protos {
      * transaction signers added to the wallet
      * </pre>
      */
-    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder>
         getTransactionSignersOrBuilderList() {
       return transactionSigners_;
     }
@@ -15516,7 +15721,7 @@ public final class Protos {
      * Protobuf type {@code wallet.Wallet}
      *
      * <pre>
-     ** A bitcoin wallet 
+     ** A bitcoin wallet
      * </pre>
      */
     public static final class Builder extends
@@ -15790,7 +15995,7 @@ public final class Protos {
               keyBuilder_ = null;
               key_ = other.key_;
               bitField0_ = (bitField0_ & ~0x00000010);
-              keyBuilder_ = 
+              keyBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getKeyFieldBuilder() : null;
             } else {
@@ -15816,7 +16021,7 @@ public final class Protos {
               transactionBuilder_ = null;
               transaction_ = other.transaction_;
               bitField0_ = (bitField0_ & ~0x00000020);
-              transactionBuilder_ = 
+              transactionBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getTransactionFieldBuilder() : null;
             } else {
@@ -15842,7 +16047,7 @@ public final class Protos {
               watchedScriptBuilder_ = null;
               watchedScript_ = other.watchedScript_;
               bitField0_ = (bitField0_ & ~0x00000040);
-              watchedScriptBuilder_ = 
+              watchedScriptBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getWatchedScriptFieldBuilder() : null;
             } else {
@@ -15877,7 +16082,7 @@ public final class Protos {
               extensionBuilder_ = null;
               extension_ = other.extension_;
               bitField0_ = (bitField0_ & ~0x00000400);
-              extensionBuilder_ = 
+              extensionBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getExtensionFieldBuilder() : null;
             } else {
@@ -15911,7 +16116,7 @@ public final class Protos {
               tagsBuilder_ = null;
               tags_ = other.tags_;
               bitField0_ = (bitField0_ & ~0x00002000);
-              tagsBuilder_ = 
+              tagsBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getTagsFieldBuilder() : null;
             } else {
@@ -15937,7 +16142,7 @@ public final class Protos {
               transactionSignersBuilder_ = null;
               transactionSigners_ = other.transactionSigners_;
               bitField0_ = (bitField0_ & ~0x00004000);
-              transactionSignersBuilder_ = 
+              transactionSignersBuilder_ =
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getTransactionSignersFieldBuilder() : null;
             } else {
@@ -15951,48 +16156,48 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasNetworkIdentifier()) {
-          
+
           return false;
         }
         for (int i = 0; i < getKeyCount(); i++) {
           if (!getKey(i).isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getTransactionCount(); i++) {
           if (!getTransaction(i).isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getWatchedScriptCount(); i++) {
           if (!getWatchedScript(i).isInitialized()) {
-            
+
             return false;
           }
         }
         if (hasEncryptionParameters()) {
           if (!getEncryptionParameters().isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getExtensionCount(); i++) {
           if (!getExtension(i).isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getTagsCount(); i++) {
           if (!getTags(i).isInitialized()) {
-            
+
             return false;
           }
         }
         for (int i = 0; i < getTransactionSignersCount(); i++) {
           if (!getTransactionSigners(i).isInitialized()) {
-            
+
             return false;
           }
         }
@@ -16061,7 +16266,7 @@ public final class Protos {
           getNetworkIdentifierBytes() {
         java.lang.Object ref = networkIdentifier_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           networkIdentifier_ = b;
@@ -16444,7 +16649,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.KeyOrBuilder>
            getKeyOrBuilderList() {
         if (keyBuilder_ != null) {
           return keyBuilder_.getMessageOrBuilderList();
@@ -16470,12 +16675,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.Key.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.Key.Builder>
            getKeyBuilderList() {
         return getKeyFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.Key, org.bitcoinj.wallet.Protos.Key.Builder, org.bitcoinj.wallet.Protos.KeyOrBuilder> 
+          org.bitcoinj.wallet.Protos.Key, org.bitcoinj.wallet.Protos.Key.Builder, org.bitcoinj.wallet.Protos.KeyOrBuilder>
           getKeyFieldBuilder() {
         if (keyBuilder_ == null) {
           keyBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -16684,7 +16889,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionOrBuilder>
            getTransactionOrBuilderList() {
         if (transactionBuilder_ != null) {
           return transactionBuilder_.getMessageOrBuilderList();
@@ -16710,12 +16915,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.Transaction.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.Transaction.Builder>
            getTransactionBuilderList() {
         return getTransactionFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.Transaction, org.bitcoinj.wallet.Protos.Transaction.Builder, org.bitcoinj.wallet.Protos.TransactionOrBuilder> 
+          org.bitcoinj.wallet.Protos.Transaction, org.bitcoinj.wallet.Protos.Transaction.Builder, org.bitcoinj.wallet.Protos.TransactionOrBuilder>
           getTransactionFieldBuilder() {
         if (transactionBuilder_ == null) {
           transactionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -16924,7 +17129,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.ScriptOrBuilder>
            getWatchedScriptOrBuilderList() {
         if (watchedScriptBuilder_ != null) {
           return watchedScriptBuilder_.getMessageOrBuilderList();
@@ -16950,12 +17155,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.Script.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.Script.Builder>
            getWatchedScriptBuilderList() {
         return getWatchedScriptFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.Script, org.bitcoinj.wallet.Protos.Script.Builder, org.bitcoinj.wallet.Protos.ScriptOrBuilder> 
+          org.bitcoinj.wallet.Protos.Script, org.bitcoinj.wallet.Protos.Script.Builder, org.bitcoinj.wallet.Protos.ScriptOrBuilder>
           getWatchedScriptFieldBuilder() {
         if (watchedScriptBuilder_ == null) {
           watchedScriptBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -17107,7 +17312,7 @@ public final class Protos {
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          org.bitcoinj.wallet.Protos.ScryptParameters, org.bitcoinj.wallet.Protos.ScryptParameters.Builder, org.bitcoinj.wallet.Protos.ScryptParametersOrBuilder> 
+          org.bitcoinj.wallet.Protos.ScryptParameters, org.bitcoinj.wallet.Protos.ScryptParameters.Builder, org.bitcoinj.wallet.Protos.ScryptParametersOrBuilder>
           getEncryptionParametersFieldBuilder() {
         if (encryptionParametersBuilder_ == null) {
           encryptionParametersBuilder_ = new com.google.protobuf.SingleFieldBuilder<
@@ -17371,7 +17576,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.ExtensionOrBuilder>
            getExtensionOrBuilderList() {
         if (extensionBuilder_ != null) {
           return extensionBuilder_.getMessageOrBuilderList();
@@ -17397,12 +17602,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.Extension.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.Extension.Builder>
            getExtensionBuilderList() {
         return getExtensionFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.Extension, org.bitcoinj.wallet.Protos.Extension.Builder, org.bitcoinj.wallet.Protos.ExtensionOrBuilder> 
+          org.bitcoinj.wallet.Protos.Extension, org.bitcoinj.wallet.Protos.Extension.Builder, org.bitcoinj.wallet.Protos.ExtensionOrBuilder>
           getExtensionFieldBuilder() {
         if (extensionBuilder_ == null) {
           extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -17459,7 +17664,7 @@ public final class Protos {
           getDescriptionBytes() {
         java.lang.Object ref = description_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           description_ = b;
@@ -17767,7 +17972,7 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TagOrBuilder>
            getTagsOrBuilderList() {
         if (tagsBuilder_ != null) {
           return tagsBuilder_.getMessageOrBuilderList();
@@ -17793,12 +17998,12 @@ public final class Protos {
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.Tag.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.Tag.Builder>
            getTagsBuilderList() {
         return getTagsFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.Tag, org.bitcoinj.wallet.Protos.Tag.Builder, org.bitcoinj.wallet.Protos.TagOrBuilder> 
+          org.bitcoinj.wallet.Protos.Tag, org.bitcoinj.wallet.Protos.Tag.Builder, org.bitcoinj.wallet.Protos.TagOrBuilder>
           getTagsFieldBuilder() {
         if (tagsBuilder_ == null) {
           tagsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -18067,7 +18272,7 @@ public final class Protos {
        * transaction signers added to the wallet
        * </pre>
        */
-      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder>
            getTransactionSignersOrBuilderList() {
         if (transactionSignersBuilder_ != null) {
           return transactionSignersBuilder_.getMessageOrBuilderList();
@@ -18105,12 +18310,12 @@ public final class Protos {
        * transaction signers added to the wallet
        * </pre>
        */
-      public java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner.Builder> 
+      public java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner.Builder>
            getTransactionSignersBuilderList() {
         return getTransactionSignersFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.bitcoinj.wallet.Protos.TransactionSigner, org.bitcoinj.wallet.Protos.TransactionSigner.Builder, org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+          org.bitcoinj.wallet.Protos.TransactionSigner, org.bitcoinj.wallet.Protos.TransactionSigner.Builder, org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder>
           getTransactionSignersFieldBuilder() {
         if (transactionSignersBuilder_ == null) {
           transactionSignersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
@@ -18203,7 +18408,7 @@ public final class Protos {
    * Protobuf type {@code wallet.ExchangeRate}
    *
    * <pre>
-   ** An exchange rate between Bitcoin and some fiat currency. 
+   ** An exchange rate between Bitcoin and some fiat currency.
    * </pre>
    */
   public static final class ExchangeRate extends
@@ -18381,7 +18586,7 @@ public final class Protos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -18401,7 +18606,7 @@ public final class Protos {
         getFiatCurrencyCodeBytes() {
       java.lang.Object ref = fiatCurrencyCode_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         fiatCurrencyCode_ = b;
@@ -18553,7 +18758,7 @@ public final class Protos {
      * Protobuf type {@code wallet.ExchangeRate}
      *
      * <pre>
-     ** An exchange rate between Bitcoin and some fiat currency. 
+     ** An exchange rate between Bitcoin and some fiat currency.
      * </pre>
      */
     public static final class Builder extends
@@ -18671,15 +18876,15 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasCoinValue()) {
-          
+
           return false;
         }
         if (!hasFiatValue()) {
-          
+
           return false;
         }
         if (!hasFiatCurrencyCode()) {
-          
+
           return false;
         }
         return true;
@@ -18843,7 +19048,7 @@ public final class Protos {
           getFiatCurrencyCodeBytes() {
         java.lang.Object ref = fiatCurrencyCode_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           fiatCurrencyCode_ = b;
@@ -19111,7 +19316,7 @@ public final class Protos {
     internal_static_wallet_Key_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_wallet_Key_descriptor,
-        new java.lang.String[] { "Type", "SecretBytes", "EncryptedData", "PublicKey", "Label", "CreationTimestamp", "DeterministicKey", "DeterministicSeed", "EncryptedDeterministicSeed", });
+        new java.lang.String[] { "Type", "SecretBytes", "EncryptedData", "PublicKey", "Label", "CreationTimestamp", "DeterministicKey", "DeterministicSeed", "EncryptedDeterministicSeed", "AccountPath"});
     internal_static_wallet_Script_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_wallet_Script_fieldAccessorTable = new

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -294,6 +294,52 @@ public class Wallet extends BaseTaggableObject
         return new Wallet(params, new KeyChainGroup(params, spendKey, false));
     }
 
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given spending key. A
+     * spending key corresponds to account zero in the recommended BIP32 key hierarchy.  This wallet can also spend.
+     */
+    public static Wallet fromSpendingKey(NetworkParameters params, DeterministicKey spendKey,
+                                         ImmutableList<ChildNumber> accountPath) {
+        return new Wallet(params, new KeyChainGroup(params, spendKey, false, accountPath));
+    }
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given spending key. A
+     * watching key corresponds to account zero in the recommended BIP32 key hierarchy. The key is specified in base58
+     * notation and the creation time of the key. If you don't know the creation time, you can pass
+     * {@link DeterministicHierarchy#BIP32_STANDARDISATION_TIME_SECS}.
+     */
+    public static Wallet fromSpendingKeyB58(NetworkParameters params, String spendingKeyB58, long creationTimeSeconds,
+                                            ImmutableList<ChildNumber> accountPath) {
+        final DeterministicKey spendKey = DeterministicKey.deserializeB58(null, spendingKeyB58, params);
+        spendKey.setCreationTimeSeconds(creationTimeSeconds);
+        return fromSpendingKey(params, spendKey);
+    }
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given spending key. A
+     * watching key corresponds to account zero in the recommended BIP32 key hierarchy. The key is specified in base58
+     * notation and the creation time of the key. If you don't know the creation time, you can pass
+     * {@link DeterministicHierarchy#BIP32_STANDARDISATION_TIME_SECS}.
+     */
+    public static Wallet fromSpendingKeyB58(NetworkParameters params, String spendingKeyB58, long creationTimeSeconds) {
+        final DeterministicKey spendKey = DeterministicKey.deserializeB58(null, spendingKeyB58, params);
+        spendKey.setCreationTimeSeconds(creationTimeSeconds);
+        return fromSpendingKey(params, spendKey);
+    }
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given spending key. A
+     * spending key corresponds to account zero in the recommended BIP32 key hierarchy.  This wallet can also spend.
+     */
+    public static Wallet fromMasterKey(NetworkParameters params, DeterministicKey masterKey, int accountNumber) {
+        return new Wallet(params, KeyChainGroup.createSpendingOrWatchingKeyChainGroup(params,
+                HDKeyDerivation.deriveChildKey(
+                        masterKey, new ChildNumber(accountNumber, true), masterKey.getCreationTimeSeconds()),
+                true));
+    }
+
     /**
      * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. A
      * watching key corresponds to account zero in the recommended BIP32 key hierarchy. The key is specified in base58

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -280,6 +280,21 @@ public class Wallet extends BaseTaggableObject
     }
 
     /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. The account path is specified.
+     */
+    public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey, ImmutableList<ChildNumber> accountPath) {
+        return new Wallet(params, new KeyChainGroup(params, watchKey, accountPath));
+    }
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given spending key. A
+     * spending key corresponds to account zero in the recommended BIP32 key hierarchy.  This wallet can also spend.
+     */
+    public static Wallet fromSpendingKey(NetworkParameters params, DeterministicKey spendKey) {
+        return new Wallet(params, new KeyChainGroup(params, spendKey, false));
+    }
+
+    /**
      * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. A
      * watching key corresponds to account zero in the recommended BIP32 key hierarchy. The key is specified in base58
      * notation and the creation time of the key. If you don't know the creation time, you can pass
@@ -289,6 +304,17 @@ public class Wallet extends BaseTaggableObject
         final DeterministicKey watchKey = DeterministicKey.deserializeB58(null, watchKeyB58, params);
         watchKey.setCreationTimeSeconds(creationTimeSeconds);
         return fromWatchingKey(params, watchKey);
+    }
+
+    /**
+     * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. The account path
+     * is specified. The key is specified in base58 notation and the creation time of the key. If you don't know the creation time,
+     * you can pass {@link DeterministicHierarchy#BIP32_STANDARDISATION_TIME_SECS}.
+     */
+    public static Wallet fromWatchingKeyB58(NetworkParameters params, String watchKeyB58, long creationTimeSeconds, ImmutableList<ChildNumber> accountPath) {
+        final DeterministicKey watchKey = DeterministicKey.deserializeB58(null, watchKeyB58, params);
+        watchKey.setCreationTimeSeconds(creationTimeSeconds);
+        return fromWatchingKey(params, watchKey, accountPath);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -80,7 +80,7 @@ public class DeterministicKeyChainTest {
         chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         chain.getKey(KeyChain.KeyPurpose.CHANGE);
         chain.maybeLookAhead();
-        assertEquals(2, chain.getKeys(false).size());
+        assertEquals(2, chain.getKeys(false,false).size());
     }
 
     @Test
@@ -131,6 +131,11 @@ public class DeterministicKeyChainTest {
 
         List<Protos.Key> keys = chain1.serializeToProtobuf();
         KeyChainFactory factory = new KeyChainFactory() {
+            @Override
+            public DeterministicKeyChain makeKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicSeed seed, KeyCrypter crypter, boolean isMarried, String originalAccountPath) {
+                return new AccountOneChain(crypter, seed);
+            }
+
             @Override
             public DeterministicKeyChain makeKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicSeed seed, KeyCrypter crypter, boolean isMarried) {
                 return new AccountOneChain(crypter, seed);

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -145,6 +145,16 @@ public class DeterministicKeyChainTest {
             public DeterministicKeyChain makeWatchingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey, boolean isFollowingKey, boolean isMarried) {
                 throw new UnsupportedOperationException();
             }
+
+            @Override
+            public DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey, boolean isMarried) throws UnreadableWalletException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public DeterministicKeyChain makeSpendingKeyChain(Protos.Key key, Protos.Key firstSubKey, DeterministicKey accountKey, boolean isMarried, ImmutableList<ChildNumber> accountPath) throws UnreadableWalletException {
+                throw new UnsupportedOperationException();
+            }
         };
 
         chain1 = DeterministicKeyChain.fromProtobuf(keys, null, factory).get(0);


### PR DESCRIPTION
As long as basicKeyChain does not import key if it is already contained, and the criteria of key in keychain is a public key on write same criteria should be used.
Reason:
Key may not be fully consistent with the one in keychain (for instance creationTime may differ)