### PR TITLE
replace ByteString with ByteBuffer in BasicKeyChain

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -890,7 +890,7 @@ public class Block extends Message {
 
     static final byte[] EMPTY_BYTES = new byte[32];
 
-    // It's pretty weak to have this around at runtime: fix later.
+    // FIXME: It's pretty weak to have this around at runtime: fix later.
     private static final byte[] pubkeyForTesting = new ECKey().getPubKey();
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -29,6 +29,8 @@ import com.google.protobuf.ByteString;
 import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -45,8 +47,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
     private final ReentrantLock lock = Threading.lock("BasicKeyChain");
 
     // Maps used to let us quickly look up a key given data we find in transcations or the block chain.
-    private final LinkedHashMap<ByteString, ECKey> hashToKeys;
-    private final LinkedHashMap<ByteString, ECKey> pubkeyToKeys;
+    private final LinkedHashMap<ByteBuffer, ECKey> hashToKeys = new LinkedHashMap<>();
+    private final LinkedHashMap<ByteBuffer, ECKey> pubkeyToKeys = new LinkedHashMap<>();
     @Nullable private final KeyCrypter keyCrypter;
     private boolean isWatching;
 
@@ -58,8 +60,6 @@ public class BasicKeyChain implements EncryptableKeyChain {
 
     public BasicKeyChain(@Nullable KeyCrypter crypter) {
         this.keyCrypter = crypter;
-        hashToKeys = new LinkedHashMap<ByteString, ECKey>();
-        pubkeyToKeys = new LinkedHashMap<ByteString, ECKey>();
         listeners = new CopyOnWriteArrayList<ListenerRegistration<KeyChainEventListener>>();
     }
 
@@ -177,8 +177,10 @@ public class BasicKeyChain implements EncryptableKeyChain {
             if (!key.isWatching() && isWatching)
                 throw new IllegalArgumentException("Key is not watching but chain is");
         }
-        ECKey previousKey = pubkeyToKeys.put(ByteString.copyFrom(key.getPubKey()), key);
-        hashToKeys.put(ByteString.copyFrom(key.getPubKeyHash()), key);
+        byte [] pubKey = key.getPubKey();
+        byte [] pubKeyHash = key.getPubKeyHash();
+        ECKey previousKey = pubkeyToKeys.put(ByteBuffer.wrap(Arrays.copyOf(pubKey, pubKey.length)), key);
+        hashToKeys.put(ByteBuffer.wrap(Arrays.copyOf(pubKeyHash, pubKeyHash.length)), key);
         checkState(previousKey == null);
     }
 
@@ -206,7 +208,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
     public ECKey findKeyFromPubHash(byte[] pubkeyHash) {
         lock.lock();
         try {
-            return hashToKeys.get(ByteString.copyFrom(pubkeyHash));
+            return hashToKeys.get(ByteBuffer.wrap(pubkeyHash));
         } finally {
             lock.unlock();
         }
@@ -215,7 +217,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
     public ECKey findKeyFromPubKey(byte[] pubkey) {
         lock.lock();
         try {
-            return pubkeyToKeys.get(ByteString.copyFrom(pubkey));
+            return pubkeyToKeys.get(ByteBuffer.wrap(pubkey));
         } finally {
             lock.unlock();
         }
@@ -261,8 +263,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
     public boolean removeKey(ECKey key) {
         lock.lock();
         try {
-            boolean a = hashToKeys.remove(ByteString.copyFrom(key.getPubKeyHash())) != null;
-            boolean b = pubkeyToKeys.remove(ByteString.copyFrom(key.getPubKey())) != null;
+            boolean a = hashToKeys.remove(ByteBuffer.wrap(key.getPubKeyHash())) != null;
+            boolean b = pubkeyToKeys.remove(ByteBuffer.wrap(key.getPubKey())) != null;
             checkState(a == b);   // Should be in both maps or neither.
             return a;
         } finally {

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -177,10 +177,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
             if (!key.isWatching() && isWatching)
                 throw new IllegalArgumentException("Key is not watching but chain is");
         }
-        byte [] pubKey = key.getPubKey();
-        byte [] pubKeyHash = key.getPubKeyHash();
-        ECKey previousKey = pubkeyToKeys.put(ByteBuffer.wrap(pubKey), key);
-        hashToKeys.put(ByteBuffer.wrap(pubKeyHash), key);
+        ECKey previousKey = pubkeyToKeys.put(ByteBuffer.wrap(key.getPubKey()), key);
+        hashToKeys.put(ByteBuffer.wrap(key.getPubKeyHash()), key);
         checkState(previousKey == null);
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -179,8 +179,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
         }
         byte [] pubKey = key.getPubKey();
         byte [] pubKeyHash = key.getPubKeyHash();
-        ECKey previousKey = pubkeyToKeys.put(ByteBuffer.wrap(Arrays.copyOf(pubKey, pubKey.length)), key);
-        hashToKeys.put(ByteBuffer.wrap(Arrays.copyOf(pubKeyHash, pubKeyHash.length)), key);
+        ECKey previousKey = pubkeyToKeys.put(ByteBuffer.wrap(pubKey), key);
+        hashToKeys.put(ByteBuffer.wrap(pubKeyHash), key);
         checkState(previousKey == null);
     }
 


### PR DESCRIPTION
In BasicKeyChain, map lookups always involved copying byte arrays to instantiate ByteStrings which were used as keys to the maps, creating a lot of garbage and wasting time copying byte arrays for simple lookups.
ByteString features good immutability but immutability can be assured with a bit of care, here, too. The replaced ByteStrings were all keys to maps that never get exposed to other classes and when written into the
map, a copy is being used as before. ByteBuffer is probably the most light-weight way of achieving this.