### PR TITLE
Overlapping file lock

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -267,6 +267,7 @@ public class SPVBlockStore implements BlockStore {
                 WindowsMMapHack.forceRelease(buffer);
             }
             buffer = null;  // Allow it to be GCd and the underlying file mapping to go away.
+            fileLock.release();
             randomAccessFile.close();
         } catch (IOException e) {
             throw new BlockStoreException(e);


### PR DESCRIPTION
File lock is taken in constructor and never released. I suppose that it should be released on store close ant this may cause our crash.